### PR TITLE
Intsidendi algus ja lõpp kuupäevade kontroll

### DIFF
--- a/PiiriAhi/.classpath
+++ b/PiiriAhi/.classpath
@@ -2,8 +2,6 @@
 <classpath>
 	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources"/>
-	<classpathentry kind="src" output="target/test-classes" path="src/test/java"/>
-	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>

--- a/PiiriAhi/log.roo
+++ b/PiiriAhi/log.roo
@@ -37,3 +37,4 @@ field string --fieldName sulgeja --notNull
 field date --fieldName suletud --type java.util.Calendar --notNull
 web mvc all --package ~.web
 web mvc all --package ~.web
+// Spring Roo 1.1.5.RELEASE [rev d3a68c3] log opened at 2011-12-18 17:06:15

--- a/PiiriAhi/src/main/java/ee/itcollege/team24/entities/PiirivalvurIntsidendis.java
+++ b/PiiriAhi/src/main/java/ee/itcollege/team24/entities/PiirivalvurIntsidendis.java
@@ -110,5 +110,9 @@ public class PiirivalvurIntsidendis extends BaseHistoryEntity implements Seriali
 	public void setVahtkondIntsidendis(VahtkondIntsidendis param) {
 	    this.vahtkondIntsidendis = param;
 	}
+	public static PiirivalvurIntsidendis findPiirivalvurIntsidendis(long parseLong) {
+		// TODO Auto-generated method stub
+		return null;
+	}
    
 }

--- a/PiiriAhi/src/main/java/ee/itcollege/team24/web/RegisterIncidentController.java
+++ b/PiiriAhi/src/main/java/ee/itcollege/team24/web/RegisterIncidentController.java
@@ -7,6 +7,7 @@ import org.springframework.roo.addon.web.mvc.controller.RooWebScaffold;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
+import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -28,6 +29,12 @@ public class RegisterIncidentController {
         if (bindingResult.hasErrors()) {
             uiModel.addAttribute("intsident", intsident);
             addDateTimeFormatPatterns(uiModel);
+            return "registerincident/create";
+        }
+        if(intsident.getToimumise_algus().after(intsident.getToimumise_lopp())){
+            uiModel.addAttribute("intsident", intsident);
+            addDateTimeFormatPatterns(uiModel);
+            bindingResult.addError(new ObjectError("toimumise_lopp","Intsidendi toimumise lõpp peab olema hiljem kui algus!"));
             return "registerincident/create";
         }
         uiModel.asMap().clear();


### PR DESCRIPTION
Lisasin kontrolli intsidendi toimumise alguse ja lõpp kuupäeva
võrdlemiseks. Nüüd ei ole võimalik lisada intsidenti, mille lõpp on
varem kui algus.
Parandus on mõistlik, sest on loogika vastane, et sündmuse lõpp kuupäev
on varem, kui algus kuupäev.
